### PR TITLE
Change the confusing text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After creating your assets in the way you want (Less, SCSS, Stylus, ES2015, ...)
 ```shell
 $ adonis assets
 # adonis assets --watch -> Watch for change
-# adonis assets --prod -> Minify for production
+# adonis assets --production -> Minify for production
 ```
 
 Laravel Mix will automaticaly download packages you need to compiles your assets and will then run them.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The config file is [Laravel Mix](https://laravel-mix.com/docs/4.0/installation) 
 For simple AdonisJS project you can use following configuration
 
 ```js
+const mix = require('laravel-mix')
+
 mix.setPublicPath('public')
 
 mix


### PR DESCRIPTION
There is some information that confusing on the README.

This is what I fixed :
- Production command should be `--production`, not `--prod`
- It's better to place `require('laravel-mix')` on the example configuration